### PR TITLE
Fixed save button behavior of the change password form.

### DIFF
--- a/frontend/components/ChangePasswordForm/index.jsx
+++ b/frontend/components/ChangePasswordForm/index.jsx
@@ -43,7 +43,7 @@ class ChangePasswordForm extends Component {
     super(props);
 
     this.state = {
-      disabled: false,
+      disabled: true,
       user: {
         password: '',
         oldPassword: '',
@@ -92,6 +92,12 @@ class ChangePasswordForm extends Component {
     this.setState(newState);
   }
 
+  componentWillUnmount = () => {
+    if (isIos) {
+      UIEvents.removeAllListeners(events.APP_BAR_SAVE_BUTTON_CLICK);
+    }
+  }
+
   /**
    * @returns {boolean}
    */
@@ -123,10 +129,28 @@ class ChangePasswordForm extends Component {
    * Triggers validation of the user fields in the state and updates the "error" field in the state.
    */
   validateInline = () => {
+    // Inline validation is only enabled after the first form submit
     if (!this.state.inlineValidation) {
+      // Enable the save button as soon as all fields are set for better usability (no validation)
+      const newState = {
+        disabled: this.state.user.password === ''
+          || this.state.user.oldPassword === ''
+          || this.state.user.repeatPassword === '',
+      };
+
+      if (isIos) {
+        if (!newState.disabled) {
+          this.enableSaveButton();
+        } else {
+          this.disableSaveButton();
+        }
+      }
+      this.setState(newState);
+
       return;
     }
 
+    // Check validation whenever inline validation is active (on form submit)
     const errors = this.props.validatePassword(this.state.user);
     this.setState({
       errors,

--- a/frontend/components/ChangePasswordForm/index.jsx
+++ b/frontend/components/ChangePasswordForm/index.jsx
@@ -152,12 +152,13 @@ class ChangePasswordForm extends Component {
 
     // Check validation whenever inline validation is active (on form submit)
     const errors = this.props.validatePassword(this.state.user);
+    const disabled = Object.keys(errors).length > 0;
     this.setState({
       errors,
-      disabled: Object.keys(errors).length > 0,
+      disabled,
     });
     if (isIos) {
-      if (Object.keys(errors).length) {
+      if (disabled) {
         this.disableSaveButton();
       } else {
         this.enableSaveButton();
@@ -176,11 +177,11 @@ class ChangePasswordForm extends Component {
       errors,
       disabled: true,
     });
+    if (isIos) {
+      this.disableSaveButton();
+    }
 
     if (Object.keys(errors).length > 0) {
-      if (isIos) {
-        this.disableSaveButton();
-      }
       return;
     }
 

--- a/frontend/locale/de-DE.json
+++ b/frontend/locale/de-DE.json
@@ -11,9 +11,9 @@
   },
   "password": {
     "update": "Passwort ändern",
-    "current": "Aktuell Passwort *",
-    "new": "Neue Passwort *",
-    "repeat": "Neue Passwort bestätigen *",
+    "current": "Aktuelles Passwort *",
+    "new": "Neues Passwort *",
+    "repeat": "Neues Passwort bestätigen *",
     "save": "Speichern",
     "errors": {
       "blank": "Bitte vervollständigen Sie dieses Feld.",


### PR DESCRIPTION
# Pull Request Template

## Description

The save button is now activated as soon as all fields are filled out, while field validation is not activated. After form submission and therefore activation of the form validation, the save button is handled as before.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
